### PR TITLE
Feature/more tags and options

### DIFF
--- a/app/src/main/java/com/piledrive/inventory/data/model/Tag.kt
+++ b/app/src/main/java/com/piledrive/inventory/data/model/Tag.kt
@@ -38,19 +38,18 @@ data class Tag(
 		level = DeprecationLevel.WARNING
 	)
 	@Json(name = "show_empty")
-	val showEmptyRaw: Int = 0
+	val showEmptyRaw: Int = 0,
 ) : TagImpl, FullDataModel, SupaBaseModel {
 	override val showEmpty: Boolean
 		get() = showEmptyRaw == 1
 }
 
-val everythingTag = Tag(STATIC_ID_TAG_ALL, "", "Everything")
+val everythingTag = Tag(predefined = true, STATIC_ID_TAG_ALL, "", "Everything")
 val predefinedTagSet: List<Tag> = listOf(
-	everythingTag,
-	Tag(STATIC_ID_TAG_MEAT, createdAt = "", name = "Meat"),
-	Tag(STATIC_ID_TAG_VEGGIES, createdAt = "", name = "Veggies"),
-	Tag(STATIC_ID_TAG_FRUIT, createdAt = "", name = "Fruit"),
-	Tag(STATIC_ID_TAG_LEFTOVERS, createdAt = "", name = "Leftovers"),
-	Tag(STATIC_ID_TAG_STAPLES, createdAt = "", name = "Staples", showEmptyRaw = 1),
-	Tag(STATIC_ID_TAG_PREPARED, createdAt = "", name = "Prepared"),
+	Tag(predefined = true, STATIC_ID_TAG_MEAT, createdAt = "", name = "Meat"),
+	Tag(predefined = true, STATIC_ID_TAG_VEGGIES, createdAt = "", name = "Veggies"),
+	Tag(predefined = true, STATIC_ID_TAG_FRUIT, createdAt = "", name = "Fruit"),
+	Tag(predefined = true, STATIC_ID_TAG_LEFTOVERS, createdAt = "", name = "Leftovers"),
+	Tag(predefined = true, STATIC_ID_TAG_STAPLES, createdAt = "", name = "Staples", showEmptyRaw = 1),
+	Tag(predefined = true, STATIC_ID_TAG_PREPARED, createdAt = "", name = "Prepared"),
 )

--- a/app/src/main/java/com/piledrive/inventory/data/model/Tag.kt
+++ b/app/src/main/java/com/piledrive/inventory/data/model/Tag.kt
@@ -50,6 +50,6 @@ val predefinedTagSet: List<Tag> = listOf(
 	Tag(STATIC_ID_TAG_VEGGIES, createdAt = "", name = "Veggies"),
 	Tag(STATIC_ID_TAG_FRUIT, createdAt = "", name = "Fruit"),
 	Tag(STATIC_ID_TAG_LEFTOVERS, createdAt = "", name = "Leftovers"),
-	Tag(STATIC_ID_TAG_STAPLES, createdAt = "", name = "Staples"),
+	Tag(STATIC_ID_TAG_STAPLES, createdAt = "", name = "Staples", showEmptyRaw = 1),
 	Tag(STATIC_ID_TAG_PREPARED, createdAt = "", name = "Prepared"),
 )

--- a/app/src/main/java/com/piledrive/inventory/data/model/Tag.kt
+++ b/app/src/main/java/com/piledrive/inventory/data/model/Tag.kt
@@ -27,6 +27,7 @@ data class TagSlug(
 
 @JsonClass(generateAdapter = true)
 data class Tag(
+	val predefined: Boolean = false,
 	override val id: String = "",
 	@Json(name = "created_at")
 	override val createdAt: String,

--- a/app/src/main/java/com/piledrive/inventory/data/model/Tag.kt
+++ b/app/src/main/java/com/piledrive/inventory/data/model/Tag.kt
@@ -6,7 +6,13 @@ import com.piledrive.inventory.data.model.abstracts.SupaBaseModel
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
-val STATIC_ID_TAG_ALL = "48ac0930-8ae4-41ec-a15c-5acd47c5c2dd"
+const val STATIC_ID_TAG_ALL = "48ac0930-8ae4-41ec-a15c-5acd47c5c2dd"
+const val STATIC_ID_TAG_MEAT = "f537d5e3-f3c8-41d9-b577-f3609a1d097c"
+const val STATIC_ID_TAG_VEGGIES = "4f66396b-1503-40cf-b168-dba9c593d510"
+const val STATIC_ID_TAG_FRUIT = "bb5c6c6d-dd66-4a41-bad5-1a5861f8f166"
+const val STATIC_ID_TAG_LEFTOVERS = "722aaed3-77ea-415f-afec-e3a3149a8bf9"
+const val STATIC_ID_TAG_STAPLES = "adeed3f9-0aed-4dc9-a8dd-306d10d950cd"
+const val STATIC_ID_TAG_PREPARED = "d0720703-a76c-4a41-9b78-0e6b57c09d33"
 
 //@Serializable
 interface TagImpl {
@@ -31,8 +37,19 @@ data class Tag(
 		level = DeprecationLevel.WARNING
 	)
 	@Json(name = "show_empty")
-	private val showEmptyRaw: Int = 0
+	val showEmptyRaw: Int = 0
 ) : TagImpl, FullDataModel, SupaBaseModel {
 	override val showEmpty: Boolean
 		get() = showEmptyRaw == 1
 }
+
+val everythingTag = Tag(STATIC_ID_TAG_ALL, "", "Everything")
+val predefinedTagSet: List<Tag> = listOf(
+	everythingTag,
+	Tag(STATIC_ID_TAG_MEAT, createdAt = "", name = "Meat"),
+	Tag(STATIC_ID_TAG_VEGGIES, createdAt = "", name = "Veggies"),
+	Tag(STATIC_ID_TAG_FRUIT, createdAt = "", name = "Fruit"),
+	Tag(STATIC_ID_TAG_LEFTOVERS, createdAt = "", name = "Leftovers"),
+	Tag(STATIC_ID_TAG_STAPLES, createdAt = "", name = "Staples"),
+	Tag(STATIC_ID_TAG_PREPARED, createdAt = "", name = "Prepared"),
+)

--- a/app/src/main/java/com/piledrive/inventory/data/model/Tag.kt
+++ b/app/src/main/java/com/piledrive/inventory/data/model/Tag.kt
@@ -11,16 +11,28 @@ val STATIC_ID_TAG_ALL = "48ac0930-8ae4-41ec-a15c-5acd47c5c2dd"
 //@Serializable
 interface TagImpl {
 	val name: String
+	val showEmpty: Boolean
 }
 
 data class TagSlug(
-	override val name: String
-): TagImpl, SlugDataModel
+	override val name: String,
+	override val showEmpty: Boolean
+) : TagImpl, SlugDataModel
 
 @JsonClass(generateAdapter = true)
 data class Tag(
 	override val id: String = "",
 	@Json(name = "created_at")
 	override val createdAt: String,
-	override val name: String
-) : TagImpl, FullDataModel, SupaBaseModel
+	override val name: String,
+	@Deprecated(
+		message = "Do not use directly, only necessary because PowerSync/SQL doesn't support booleans",
+		replaceWith = ReplaceWith("showEmpty"),
+		level = DeprecationLevel.WARNING
+	)
+	@Json(name = "show_empty")
+	private val showEmptyRaw: Int = 0
+) : TagImpl, FullDataModel, SupaBaseModel {
+	override val showEmpty: Boolean
+		get() = showEmptyRaw == 1
+}

--- a/app/src/main/java/com/piledrive/inventory/data/powersync/AppSchema.kt
+++ b/app/src/main/java/com/piledrive/inventory/data/powersync/AppSchema.kt
@@ -64,6 +64,7 @@ val AppSchema: Schema = Schema(
 				//Column.text("id"),
 				Column.text("created_at"),
 				Column.text("name"),
+				Column.integer("show_empty")
 			)
 		),
 	)

--- a/app/src/main/java/com/piledrive/inventory/ui/modal/create_item/CreateItemModalSheet.kt
+++ b/app/src/main/java/com/piledrive/inventory/ui/modal/create_item/CreateItemModalSheet.kt
@@ -177,7 +177,7 @@ object CreateItemModalSheet {
 								)
 								coordinator.onCreateDataModel(item)
 							} else {
-								val fullTags = tagPool.data.allTags.filter { selectedTags.contains(it.id) }
+								val fullTags = tagPool.data.tagsForFiltering.filter { selectedTags.contains(it.id) }
 								val fullUnit = quantityUnitPool.data.allUnits.firstOrNull { selectedQuantityUnit == it.id }
 									?: throw IllegalStateException("target quantity unit not found")
 								val updatedItem = activeItem.copy(
@@ -233,7 +233,7 @@ object CreateItemModalSheet {
 				Gap(12.dp)
 
 				Text("Item tags:")
-				if (tagPool.data.userTags.isEmpty()) {
+				if (tagPool.data.tagsForItems.isEmpty()) {
 					Text("No added tags yet")
 				} else {
 					ChipGroup {
@@ -246,7 +246,7 @@ object CreateItemModalSheet {
 							icon = { Icon(Icons.Default.Add, "add new tag") }
 						)
 
-						tagPool.data.userTags.forEach {
+						tagPool.data.tagsForItems.forEach {
 							val selected = selectedTags.contains(it.id)
 							FilterChip(
 								selected = selected,

--- a/app/src/main/java/com/piledrive/inventory/ui/modal/create_tag/CreateTagModalSheet.kt
+++ b/app/src/main/java/com/piledrive/inventory/ui/modal/create_tag/CreateTagModalSheet.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -70,6 +71,7 @@ object CreateTagModalSheet {
 		val tags = coordinator.tagsSourceFlow.collectAsState().value
 		val activeTag = coordinator.activeEditDataState.value
 		val initialText = remember { activeTag?.name ?: "" }
+		val readOnly = activeTag?.predefined ?: false
 
 		Surface(
 			modifier = Modifier
@@ -83,12 +85,12 @@ object CreateTagModalSheet {
 						Validators.Custom<String>(runCheck = { nameIn ->
 							val matchEdit = nameIn == activeTag?.name
 							val matchExisting =
-								tags.data.allTags.firstOrNull { it.name.equals(nameIn, true) } != null
+								tags.data.tagsForFiltering.firstOrNull { it.name.equals(nameIn, true) } != null
 							!matchExisting || matchEdit
 						}, errMsg = "Tag already exists")
 					)
 				).apply {
-					if(!initialText.isNullOrBlank()) {
+					if (!initialText.isNullOrBlank()) {
 						this.check(initialText)
 					}
 				}
@@ -105,6 +107,7 @@ object CreateTagModalSheet {
 					verticalAlignment = Alignment.CenterVertically
 				) {
 					OutlinedTextField(
+						readOnly = readOnly,
 						modifier = Modifier.weight(1f),
 						value = formState.currentValue ?: "",
 						isError = formState.hasError,
@@ -151,11 +154,11 @@ object CreateTagModalSheet {
 				Gap(12.dp)
 
 				Text("Current tags:")
-				if (tags.data.userTags.isEmpty()) {
+				if (tags.data.tagsForItems.isEmpty()) {
 					Text("No added tags yet")
 				} else {
 					ChipGroup {
-						tags.data.userTags.forEach {
+						tags.data.tagsForItems.forEach {
 							SuggestionChip(
 								onClick = {},
 								label = { Text(it.name) },

--- a/app/src/main/java/com/piledrive/inventory/ui/modal/create_tag/CreateTagModalSheet.kt
+++ b/app/src/main/java/com/piledrive/inventory/ui/modal/create_tag/CreateTagModalSheet.kt
@@ -135,7 +135,7 @@ object CreateTagModalSheet {
 							    form-level viewmodel, feels like clutter in the main VM
 							 */
 							if(activeTag == null) {
-								val slug = TagSlug(name = formState.currentValue)
+								val slug = TagSlug(name = formState.currentValue, showEmpty = false)
 								coordinator.onCreateDataModel(slug)
 							} else {
 								val updatedTag = activeTag.copy(name = formState.currentValue)

--- a/app/src/main/java/com/piledrive/inventory/ui/modal/create_tag/CreateTagModalSheet.kt
+++ b/app/src/main/java/com/piledrive/inventory/ui/modal/create_tag/CreateTagModalSheet.kt
@@ -71,6 +71,8 @@ object CreateTagModalSheet {
 		val tags = coordinator.tagsSourceFlow.collectAsState().value
 		val activeTag = coordinator.activeEditDataState.value
 		val initialText = remember { activeTag?.name ?: "" }
+		val initialShowEmpty = remember { activeTag?.showEmpty ?: false }
+		var showEmpty = remember { initialShowEmpty }
 		val readOnly = activeTag?.predefined ?: false
 
 		Surface(
@@ -137,11 +139,11 @@ object CreateTagModalSheet {
 							    requires fleshing out and/or moving form state to viewmodel, can't decide if better left internal or add
 							    form-level viewmodel, feels like clutter in the main VM
 							 */
-							if(activeTag == null) {
-								val slug = TagSlug(name = formState.currentValue, showEmpty = false)
+							if (activeTag == null) {
+								val slug = TagSlug(name = formState.currentValue, showEmpty = showEmpty)
 								coordinator.onCreateDataModel(slug)
 							} else {
-								val updatedTag = activeTag.copy(name = formState.currentValue)
+								val updatedTag = activeTag.copy(name = formState.currentValue, showEmptyRaw = if(showEmpty) 1 else 0)
 								coordinator.onUpdateDataModel(updatedTag)
 							}
 							coordinator.onDismiss()
@@ -149,6 +151,18 @@ object CreateTagModalSheet {
 					) {
 						Icon(Icons.Default.Done, contentDescription = "add new tag")
 					}
+				}
+
+				Gap(12.dp)
+
+				Text(text = "Tag options:")
+				Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+					Checkbox(
+						checked = showEmpty,
+						onCheckedChange = { showEmpty = it },
+						enabled = readOnly
+					)
+					Text(text = "Show empty")
 				}
 
 				Gap(12.dp)

--- a/app/src/main/java/com/piledrive/inventory/ui/state/MainContentState.kt
+++ b/app/src/main/java/com/piledrive/inventory/ui/state/MainContentState.kt
@@ -49,7 +49,10 @@ data class TagOptions(
 	val currentTag: Tag = defaultTag
 ) {
 
-	val allTags: List<Tag>
+	val tagsForFiltering: List<Tag>
+		get() = listOf(everythingTag, *predefinedTagSet.toTypedArray(), *userTags.toTypedArray())
+
+	val tagsForItems: List<Tag>
 		get() = listOf(*predefinedTagSet.toTypedArray(), *userTags.toTypedArray())
 
 	companion object {

--- a/app/src/main/java/com/piledrive/inventory/ui/state/MainContentState.kt
+++ b/app/src/main/java/com/piledrive/inventory/ui/state/MainContentState.kt
@@ -4,11 +4,12 @@ import com.piledrive.inventory.data.model.Item
 import com.piledrive.inventory.data.model.Location
 import com.piledrive.inventory.data.model.QuantityUnit
 import com.piledrive.inventory.data.model.STATIC_ID_LOCATION_ALL
-import com.piledrive.inventory.data.model.STATIC_ID_TAG_ALL
 import com.piledrive.inventory.data.model.Stash
 import com.piledrive.inventory.data.model.Tag
+import com.piledrive.inventory.data.model.everythingTag
 import com.piledrive.inventory.data.model.composite.StashesForItem
 import com.piledrive.inventory.data.model.composite.ItemWithTagsContent
+import com.piledrive.inventory.data.model.predefinedTagSet
 
 
 //  region location filter
@@ -49,10 +50,10 @@ data class TagOptions(
 ) {
 
 	val allTags: List<Tag>
-		get() = listOf(defaultTag, *userTags.toTypedArray())
+		get() = listOf(*predefinedTagSet.toTypedArray(), *userTags.toTypedArray())
 
 	companion object {
-		val defaultTag = Tag(STATIC_ID_TAG_ALL, "", "Everything")
+		val defaultTag = everythingTag
 	}
 }
 

--- a/app/src/main/java/com/piledrive/inventory/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/piledrive/inventory/viewmodel/MainViewModel.kt
@@ -195,7 +195,7 @@ class MainViewModel @Inject constructor(
 					)
 					withContext(Dispatchers.Main) {
 						_userTagsContentFlow.value = userTagsContent
-						filterAppBarCoordinator.tagsDropdownCoordinator.updateOptionsPool(userTagsContent.data.allTags)
+						filterAppBarCoordinator.tagsDropdownCoordinator.updateOptionsPool(userTagsContent.data.tagsForFiltering)
 						if (filterAppBarCoordinator.tagsDropdownCoordinator.selectedOptionState.value == null) {
 							filterAppBarCoordinator.tagsDropdownCoordinator.onOptionSelected(TagOptions.defaultTag)
 						}

--- a/app/src/main/java/com/piledrive/inventory/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/piledrive/inventory/viewmodel/MainViewModel.kt
@@ -405,6 +405,7 @@ class MainViewModel @Inject constructor(
 
 				val stashesForItem: List<FullStashData> = input.value
 					.map { stash ->
+						if(tagsForItem.firstOrNull { it.showEmpty } == null && stash.amount == 0.0) return@mapNotNull null
 						val location = locations.firstOrNull { it.id == stash.locationId } ?: return@mapNotNull null
 						FullStashData(stash, location)
 					}


### PR DESCRIPTION
add predefined tags for common usages (meat, veggies, leftovers, staples, etc.), including a flag column on the tag model to enbable/disable editing of tags. change content state compilation to drop empty stashes, unless newly-added "how when empty" option is enabled on tag - added for staples tag so you can see if you're out of things you commonly need.