### PR TITLE
Chore/performance

### DIFF
--- a/app/src/main/java/com/piledrive/inventory/data/model/composite/FullItemData.kt
+++ b/app/src/main/java/com/piledrive/inventory/data/model/composite/FullItemData.kt
@@ -1,8 +1,0 @@
-package com.piledrive.inventory.data.model.composite
-
-import com.piledrive.inventory.data.model.Item
-import com.piledrive.inventory.data.model.QuantityUnit
-import com.piledrive.inventory.data.model.Tag
-import com.piledrive.inventory.data.model.abstracts.FullDataModel
-
-data class FullItemData(val item: Item, val unit: QuantityUnit, val tags: List<Tag>) : FullDataModel

--- a/app/src/main/java/com/piledrive/inventory/data/model/composite/FullItemsContent.kt
+++ b/app/src/main/java/com/piledrive/inventory/data/model/composite/FullItemsContent.kt
@@ -3,13 +3,16 @@ package com.piledrive.inventory.data.model.composite
 import com.piledrive.inventory.data.model.Item
 import com.piledrive.inventory.data.model.QuantityUnit
 import com.piledrive.inventory.data.model.Tag
+import com.piledrive.inventory.data.model.abstracts.FullDataModel
 
-data class ItemWithTagsContent(
+data class FullItemData(val item: Item, val unit: QuantityUnit, val tags: List<Tag>) : FullDataModel
+
+data class FullItemsContent(
 	val fullItems: List<FullItemData> = listOf()
 ) {
 
 	companion object {
-		fun generateSampleSet(): ItemWithTagsContent {
+		fun generateSampleSet(): FullItemsContent {
 			val locationId = "l1"
 			val items = listOf<FullItemData>(
 				FullItemData(
@@ -40,7 +43,7 @@ data class ItemWithTagsContent(
 					),
 				)
 			)
-			val content = ItemWithTagsContent(items)
+			val content = FullItemsContent(items)
 			return content
 		}
 	}

--- a/app/src/main/java/com/piledrive/inventory/data/model/composite/FullStashData.kt
+++ b/app/src/main/java/com/piledrive/inventory/data/model/composite/FullStashData.kt
@@ -1,6 +1,51 @@
 package com.piledrive.inventory.data.model.composite
 
+import com.piledrive.inventory.data.model.Item
 import com.piledrive.inventory.data.model.Location
+import com.piledrive.inventory.data.model.QuantityUnit
 import com.piledrive.inventory.data.model.Stash
+import com.piledrive.inventory.data.model.Tag
 
 data class FullStashData(val stash: Stash, val location: Location)
+
+data class FullStashesContent(
+	val fullStashes: List<FullStashData> = listOf()
+) {
+
+	companion object {
+		fun generateSampleSet(): FullStashesContent {
+			val data = listOf<FullStashData>(
+				FullStashData(
+					stash = Stash(
+						id = "s1",
+						createdAt = "",
+						itemId = "i1",
+						locationId = "l1",
+						amount = 1.0
+					),
+					location = Location(
+						id = "l1",
+						createdAt = "",
+						name = "Freezer"
+					)
+				),
+				FullStashData(
+					stash = Stash(
+						id = "s2",
+						createdAt = "",
+						itemId = "i2",
+						locationId = "l2",
+						amount = 1.0
+					),
+					location = Location(
+						id = "l2",
+						createdAt = "",
+						name = "Pantry"
+					)
+				)
+			)
+			val content = FullStashesContent(data)
+			return content
+		}
+	}
+}

--- a/app/src/main/java/com/piledrive/inventory/repo/Item2TagsRepo.kt
+++ b/app/src/main/java/com/piledrive/inventory/repo/Item2TagsRepo.kt
@@ -11,8 +11,9 @@ import com.piledrive.inventory.repo.datasource.SupaBaseLocationsDataSource
 import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
+import javax.inject.Singleton
 
-@ViewModelScoped
+@Singleton
 class Item2TagsRepo @Inject constructor(
 	private val powerSyncSource: PowerSyncItem2TagsDataSource,
 	//private val localSource: LocalMoviesSource,

--- a/app/src/main/java/com/piledrive/inventory/repo/ItemStashesRepo.kt
+++ b/app/src/main/java/com/piledrive/inventory/repo/ItemStashesRepo.kt
@@ -37,7 +37,7 @@ class ItemStashesRepo @Inject constructor(
 	suspend fun performTransfer(updatedFromStash: Stash, updatedToStash: Stash) {
 		powerSyncSource.updateItemStashQuantity(updatedFromStash.id, updatedFromStash.amount)
 		if(updatedToStash.id == STATIC_ID_NEW_FROM_TRANSFER) {
-			powerSyncSource.addItemStash(StashSlug(updatedToStash.id, updatedToStash.locationId, updatedToStash.amount))
+			powerSyncSource.addItemStash(StashSlug(updatedToStash.itemId, updatedToStash.locationId, updatedToStash.amount))
 		} else {
 			powerSyncSource.updateItemStashQuantity(updatedToStash.id, updatedToStash.amount)
 		}

--- a/app/src/main/java/com/piledrive/inventory/repo/ItemStashesRepo.kt
+++ b/app/src/main/java/com/piledrive/inventory/repo/ItemStashesRepo.kt
@@ -7,8 +7,9 @@ import com.piledrive.inventory.repo.datasource.PowerSyncItemStashesDataSource
 import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
+import javax.inject.Singleton
 
-@ViewModelScoped
+@Singleton
 class ItemStashesRepo @Inject constructor(
 	private val powerSyncSource: PowerSyncItemStashesDataSource,
 	//private val localSource: LocalMoviesSource,

--- a/app/src/main/java/com/piledrive/inventory/repo/ItemsRepo.kt
+++ b/app/src/main/java/com/piledrive/inventory/repo/ItemsRepo.kt
@@ -8,8 +8,9 @@ import com.piledrive.inventory.repo.datasource.abstracts.ItemsSourceImpl
 import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
+import javax.inject.Singleton
 
-@ViewModelScoped
+@Singleton
 class ItemsRepo @Inject constructor(
 	private val powerSyncSource: PowerSyncItemsDataSource,
 	//private val localSource: LocalMoviesSource,

--- a/app/src/main/java/com/piledrive/inventory/repo/LocationsRepo.kt
+++ b/app/src/main/java/com/piledrive/inventory/repo/LocationsRepo.kt
@@ -8,8 +8,9 @@ import com.piledrive.inventory.repo.datasource.abstracts.LocationsSourceImpl
 import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
+import javax.inject.Singleton
 
-@ViewModelScoped
+@Singleton
 class LocationsRepo @Inject constructor(
 	private val powerSyncSource: PowerSyncLocationsDataSource,
 	//private val localSource: LocalMoviesSource,

--- a/app/src/main/java/com/piledrive/inventory/repo/QuantityUnitsRepo.kt
+++ b/app/src/main/java/com/piledrive/inventory/repo/QuantityUnitsRepo.kt
@@ -7,8 +7,9 @@ import com.piledrive.inventory.repo.datasource.abstracts.QuantityUnitsSourceImpl
 import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
+import javax.inject.Singleton
 
-@ViewModelScoped
+@Singleton
 class QuantityUnitsRepo @Inject constructor(
 	private val powerSyncSource: PowerSyncQuantityUnitsDataSource,
 	//private val localSource: LocalMoviesSource,

--- a/app/src/main/java/com/piledrive/inventory/repo/TagsRepo.kt
+++ b/app/src/main/java/com/piledrive/inventory/repo/TagsRepo.kt
@@ -7,8 +7,9 @@ import com.piledrive.inventory.repo.datasource.abstracts.TagsSourceImpl
 import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
+import javax.inject.Singleton
 
-@ViewModelScoped
+@Singleton
 class TagsRepo @Inject constructor(
 	private val powerSyncSource: PowerSyncTagsDataSource,
 ) : TagsSourceImpl {

--- a/app/src/main/java/com/piledrive/inventory/repo/datasource/PowerSyncItem2TagsDataSource.kt
+++ b/app/src/main/java/com/piledrive/inventory/repo/datasource/PowerSyncItem2TagsDataSource.kt
@@ -14,8 +14,9 @@ import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import javax.inject.Inject
+import javax.inject.Singleton
 
-@ViewModelScoped
+@Singleton
 class PowerSyncItem2TagsDataSource @Inject constructor(
 	private val powerSync: PowerSyncDbWrapper,
 ) : Item2TagsSourceImpl {

--- a/app/src/main/java/com/piledrive/inventory/repo/datasource/PowerSyncItemStashesDataSource.kt
+++ b/app/src/main/java/com/piledrive/inventory/repo/datasource/PowerSyncItemStashesDataSource.kt
@@ -10,8 +10,9 @@ import com.powersync.db.getString
 import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
+import javax.inject.Singleton
 
-@ViewModelScoped
+@Singleton
 class PowerSyncItemStashesDataSource @Inject constructor(
 	private val powerSync: PowerSyncDbWrapper,
 ) : ItemStashesSourceImpl {

--- a/app/src/main/java/com/piledrive/inventory/repo/datasource/PowerSyncItemsDataSource.kt
+++ b/app/src/main/java/com/piledrive/inventory/repo/datasource/PowerSyncItemsDataSource.kt
@@ -12,8 +12,9 @@ import com.powersync.db.getString
 import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
+import javax.inject.Singleton
 
-@ViewModelScoped
+@Singleton
 class PowerSyncItemsDataSource @Inject constructor(
 	private val powerSync: PowerSyncDbWrapper,
 ) : ItemsSourceImpl {

--- a/app/src/main/java/com/piledrive/inventory/repo/datasource/PowerSyncLocationsDataSource.kt
+++ b/app/src/main/java/com/piledrive/inventory/repo/datasource/PowerSyncLocationsDataSource.kt
@@ -9,8 +9,9 @@ import com.powersync.db.getString
 import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
+import javax.inject.Singleton
 
-@ViewModelScoped
+@Singleton
 class PowerSyncLocationsDataSource @Inject constructor(
 	private val powerSync: PowerSyncDbWrapper,
 ) : LocationsSourceImpl {

--- a/app/src/main/java/com/piledrive/inventory/repo/datasource/PowerSyncQuantityUnitsDataSource.kt
+++ b/app/src/main/java/com/piledrive/inventory/repo/datasource/PowerSyncQuantityUnitsDataSource.kt
@@ -10,8 +10,9 @@ import com.powersync.db.getString
 import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
+import javax.inject.Singleton
 
-@ViewModelScoped
+@Singleton
 class PowerSyncQuantityUnitsDataSource @Inject constructor(
 	private val powerSync: PowerSyncDbWrapper,
 ) : QuantityUnitsSourceImpl {

--- a/app/src/main/java/com/piledrive/inventory/repo/datasource/PowerSyncTagsDataSource.kt
+++ b/app/src/main/java/com/piledrive/inventory/repo/datasource/PowerSyncTagsDataSource.kt
@@ -9,8 +9,9 @@ import com.powersync.db.getString
 import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
+import javax.inject.Singleton
 
-@ViewModelScoped
+@Singleton
 class PowerSyncTagsDataSource @Inject constructor(
 	private val powerSync: PowerSyncDbWrapper,
 ) : TagsSourceImpl {

--- a/app/src/main/java/com/piledrive/inventory/repo/datasource/SupaBaseLocationsDataSource.kt
+++ b/app/src/main/java/com/piledrive/inventory/repo/datasource/SupaBaseLocationsDataSource.kt
@@ -13,8 +13,9 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import javax.inject.Inject
+import javax.inject.Singleton
 
-@ViewModelScoped
+@Singleton
 class SupaBaseLocationsDataSource @Inject constructor(
 	private val supaBase: SupaBaseWrapper,
 ) : LocationsSourceImpl {

--- a/app/src/main/java/com/piledrive/inventory/ui/nav/NavConfig.kt
+++ b/app/src/main/java/com/piledrive/inventory/ui/nav/NavConfig.kt
@@ -44,7 +44,7 @@ fun RootNavHost() {
 		composable(route = MainScreen.routeValue) {
 			val viewModel: MainViewModel = hiltViewModel<MainViewModel>()
 			LaunchedEffect("load_content_on_launch") {
-				viewModel.reloadContent()
+				viewModel.initDataSync()
 			}
 			MainScreen.draw(
 				viewModel,
@@ -66,7 +66,7 @@ fun RootNavHost() {
 		composable(route = ManageItemsScreen.routeValue) {
 			val viewModel: ManageItemsViewModel = hiltViewModel<ManageItemsViewModel>()
 			LaunchedEffect("load_items_content_on_launch") {
-				viewModel.reloadContent()
+				viewModel.initDataSync()
 			}
 			ManageItemsScreen.draw(
 				viewModel,

--- a/app/src/main/java/com/piledrive/inventory/ui/screens/main/content/MainContentListCoordinator.kt
+++ b/app/src/main/java/com/piledrive/inventory/ui/screens/main/content/MainContentListCoordinator.kt
@@ -4,9 +4,11 @@ import com.piledrive.inventory.data.model.Item
 import com.piledrive.inventory.data.model.Location
 import com.piledrive.inventory.data.model.composite.FullItemData
 import com.piledrive.inventory.data.model.composite.StashesForItem
+import com.piledrive.inventory.ui.state.FilterOptions
 import com.piledrive.inventory.ui.state.LocalizedContentState
 import com.piledrive.inventory.ui.state.LocationContentState
 import com.piledrive.inventory.ui.state.TagsContentState
+import com.piledrive.inventory.ui.util.previewFilterOptionsFlow
 import com.piledrive.inventory.ui.util.previewLocalizedContentFlow
 import com.piledrive.inventory.ui.util.previewLocationContentFlow
 import com.piledrive.inventory.ui.util.previewTagsContentFlow
@@ -17,6 +19,7 @@ interface MainContentListCoordinatorImpl {
 	val stashesSourceFlow: StateFlow<LocalizedContentState>
 	val locationsSourceFlow: StateFlow<LocationContentState>
 	val tagsSourceFlow: StateFlow<TagsContentState>
+	val filterOptionsFlow: StateFlow<FilterOptions>
 	val allLocationsSectionsCoordinator: SectionedListCoordinator
 	val itemMenuCoordinator: ListItemOverflowMenuCoordinator
 	val onItemStashQuantityUpdated: (stashId: String, qty: Double) -> Unit
@@ -28,6 +31,7 @@ class MainContentListCoordinator(
 	override val stashesSourceFlow: StateFlow<LocalizedContentState>,
 	override val locationsSourceFlow: StateFlow<LocationContentState>,
 	override val tagsSourceFlow: StateFlow<TagsContentState>,
+	override val filterOptionsFlow: StateFlow<FilterOptions>,
 	override val allLocationsSectionsCoordinator: SectionedListCoordinator,
 	override val itemMenuCoordinator: ListItemOverflowMenuCoordinator,
 	override val onItemStashQuantityUpdated: (stashId: String, qty: Double) -> Unit,
@@ -44,6 +48,7 @@ val stubMainContentListCoordinator = MainContentListCoordinator(
 	stashesSourceFlow = previewLocalizedContentFlow(),
 	locationsSourceFlow = previewLocationContentFlow(),
 	tagsSourceFlow = previewTagsContentFlow(),
+	filterOptionsFlow = previewFilterOptionsFlow(),
 	allLocationsSectionsCoordinator = SectionedListCoordinator(),
 	itemMenuCoordinator = ListItemOverflowMenuCoordinator(),
 	onItemStashQuantityUpdated = { _, _ -> },

--- a/app/src/main/java/com/piledrive/inventory/ui/screens/main/content/MainStashContentList.kt
+++ b/app/src/main/java/com/piledrive/inventory/ui/screens/main/content/MainStashContentList.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.zIndex
 import com.piledrive.inventory.data.model.STATIC_ID_LOCATION_ALL
 import com.piledrive.inventory.ui.screens.main.content.multi_location.MultiLocationStashContent
 import com.piledrive.inventory.ui.screens.main.content.single_location.SingleLocationStashContent
+import com.piledrive.inventory.ui.state.FilterOptions
 import com.piledrive.inventory.ui.state.LocalizedContentState
 import com.piledrive.inventory.ui.state.LocationContentState
 import com.piledrive.lib_compose_components.ui.theme.custom.AppTheme
@@ -36,11 +37,13 @@ object MainStashContentList {
 	) {
 		val itemStashContent = coordinator.stashesSourceFlow.collectAsState().value
 		val locationContent = coordinator.locationsSourceFlow.collectAsState().value
+		val filterOptions = coordinator.filterOptionsFlow.collectAsState().value
 
 		DrawContent(
 			modifier,
 			locationContent,
 			itemStashContent,
+			filterOptions,
 			coordinator,
 			onLaunchCreateLocation,
 			onLaunchCreateItemStash
@@ -52,12 +55,13 @@ object MainStashContentList {
 		modifier: Modifier = Modifier,
 		locationContent: LocationContentState,
 		itemStashContent: LocalizedContentState,
+		filterOptions: FilterOptions,
 		coordinator: MainContentListCoordinatorImpl,
 		onLaunchCreateLocation: () -> Unit,
 		onLaunchCreateItemStash: () -> Unit
 	) {
 		val stashesForLocation = itemStashContent.data.stashes
-		val currLocationId = locationContent.data.currentLocation.id
+		val currLocationId = filterOptions.currentLocation.id
 
 		Surface(
 			modifier = modifier.fillMaxSize(),
@@ -94,7 +98,7 @@ object MainStashContentList {
 							}
 						} else {
 							Text(
-								"no items in ${locationContent.data.currentLocation.name}"
+								"no items in ${filterOptions.currentLocation.name}"
 							)
 							Button(onClick = {
 								onLaunchCreateItemStash()
@@ -151,6 +155,7 @@ private fun MainStashContentListPreview() {
 			modifier = Modifier,
 			locationContent = LocationContentState(),
 			itemStashContent = LocalizedContentState(/*data = ContentForLocation.generateSampleSet()*/),
+			filterOptions = FilterOptions(),
 			stubMainContentListCoordinator,
 			onLaunchCreateLocation = {},
 			onLaunchCreateItemStash = {}

--- a/app/src/main/java/com/piledrive/inventory/ui/screens/main/content/multi_location/MultiLocationStashContent.kt
+++ b/app/src/main/java/com/piledrive/inventory/ui/screens/main/content/multi_location/MultiLocationStashContent.kt
@@ -51,8 +51,9 @@ object MultiLocationStashContent {
 	) {
 		val itemStashContent = coordinator.stashesSourceFlow.collectAsState().value
 		val stashes = itemStashContent.data.stashes
-		val currLocationId = coordinator.locationsSourceFlow.collectAsState().value.data.currentLocation.id
-		val currTagId = coordinator.tagsSourceFlow.collectAsState().value.data.currentTag.id
+		val filterOptions = coordinator.filterOptionsFlow.collectAsState().value
+		val currLocationId = filterOptions.currentLocation.id
+		val currTagId = filterOptions.currentTag.id
 		val expandedStashes = coordinator.allLocationsSectionsCoordinator.expandedSectionsState.value
 
 		DrawContent(

--- a/app/src/main/java/com/piledrive/inventory/ui/screens/main/content/single_location/SingleLocationStashContent.kt
+++ b/app/src/main/java/com/piledrive/inventory/ui/screens/main/content/single_location/SingleLocationStashContent.kt
@@ -41,8 +41,9 @@ object SingleLocationStashContent {
 	) {
 		val itemStashContent = coordinator.stashesSourceFlow.collectAsState().value
 		val stashes = itemStashContent.data.stashes
-		val currLocationId = coordinator.locationsSourceFlow.collectAsState().value.data.currentLocation.id
-		val currTagId = coordinator.tagsSourceFlow.collectAsState().value.data.currentTag.id
+		val filterOptions = coordinator.filterOptionsFlow.collectAsState().value
+		val currLocationId = filterOptions.currentLocation.id
+		val currTagId = filterOptions.currentTag.id
 
 		DrawContent(
 			modifier,

--- a/app/src/main/java/com/piledrive/inventory/ui/state/MainContentState.kt
+++ b/app/src/main/java/com/piledrive/inventory/ui/state/MainContentState.kt
@@ -6,7 +6,8 @@ import com.piledrive.inventory.data.model.QuantityUnit
 import com.piledrive.inventory.data.model.STATIC_ID_LOCATION_ALL
 import com.piledrive.inventory.data.model.Stash
 import com.piledrive.inventory.data.model.Tag
-import com.piledrive.inventory.data.model.composite.ItemWithTagsContent
+import com.piledrive.inventory.data.model.composite.FullItemsContent
+import com.piledrive.inventory.data.model.composite.FullStashesContent
 import com.piledrive.inventory.data.model.composite.StashesForItem
 import com.piledrive.inventory.data.model.everythingTag
 import com.piledrive.inventory.data.model.predefinedTagSet
@@ -140,7 +141,13 @@ data class LocalizedContentState(
 /////////////////////////////////////////////////
 
 data class FullItemsContentState(
-	override val data: ItemWithTagsContent = ItemWithTagsContent(),
+	override val data: FullItemsContent = FullItemsContent(),
+	override val hasLoaded: Boolean = false,
+	override val isLoading: Boolean = true
+) : GenericContentState()
+
+data class FullStashesContentState(
+	override val data: FullStashesContent = FullStashesContent(),
 	override val hasLoaded: Boolean = false,
 	override val isLoading: Boolean = true
 ) : GenericContentState()

--- a/app/src/main/java/com/piledrive/inventory/ui/state/MainContentState.kt
+++ b/app/src/main/java/com/piledrive/inventory/ui/state/MainContentState.kt
@@ -6,10 +6,24 @@ import com.piledrive.inventory.data.model.QuantityUnit
 import com.piledrive.inventory.data.model.STATIC_ID_LOCATION_ALL
 import com.piledrive.inventory.data.model.Stash
 import com.piledrive.inventory.data.model.Tag
-import com.piledrive.inventory.data.model.everythingTag
-import com.piledrive.inventory.data.model.composite.StashesForItem
 import com.piledrive.inventory.data.model.composite.ItemWithTagsContent
+import com.piledrive.inventory.data.model.composite.StashesForItem
+import com.piledrive.inventory.data.model.everythingTag
 import com.piledrive.inventory.data.model.predefinedTagSet
+import com.piledrive.inventory.ui.state.LocationOptions.Companion.defaultLocation
+import com.piledrive.inventory.ui.state.TagOptions.Companion.defaultTag
+
+
+//  region Content filter bar
+/////////////////////////////////////////////////
+
+data class FilterOptions(
+	val currentLocation: Location = defaultLocation,
+	val currentTag: Tag = defaultTag
+)
+
+/////////////////////////////////////////////////
+//  endregion
 
 
 //  region location filter
@@ -18,7 +32,6 @@ import com.piledrive.inventory.data.model.predefinedTagSet
 data class LocationOptions(
 	val allLocations: List<Location> = listOf(defaultLocation),
 	val userLocations: List<Location> = listOf(),
-	val currentLocation: Location = defaultLocation
 ) {
 	companion object {
 		val defaultLocation = Location(STATIC_ID_LOCATION_ALL, "", "Everywhere")
@@ -46,7 +59,6 @@ data class LocationContentState(
 
 data class TagOptions(
 	val userTags: List<Tag> = listOf(),
-	val currentTag: Tag = defaultTag
 ) {
 
 	val tagsForFiltering: List<Tag>

--- a/app/src/main/java/com/piledrive/inventory/ui/util/PreviewSampleData.kt
+++ b/app/src/main/java/com/piledrive/inventory/ui/util/PreviewSampleData.kt
@@ -8,7 +8,7 @@ import com.piledrive.inventory.data.model.QuantityUnit
 import com.piledrive.inventory.data.model.Stash
 import com.piledrive.inventory.data.model.Tag
 import com.piledrive.inventory.data.model.composite.StashesForItem
-import com.piledrive.inventory.data.model.composite.ItemWithTagsContent
+import com.piledrive.inventory.data.model.composite.FullItemsContent
 import com.piledrive.inventory.ui.state.FilterOptions
 import com.piledrive.inventory.ui.state.FullItemsContentState
 import com.piledrive.inventory.ui.state.ItemContentState
@@ -76,7 +76,7 @@ fun previewUnitsContentFlow(
 }
 
 fun previewFullItemsContentFlow(
-	dataSet: ItemWithTagsContent = ItemWithTagsContent.generateSampleSet()
+	dataSet: FullItemsContent = FullItemsContent.generateSampleSet()
 ): StateFlow<FullItemsContentState> {
 	return MutableStateFlow(FullItemsContentState(data = dataSet, hasLoaded = true, isLoading = false))
 }

--- a/app/src/main/java/com/piledrive/inventory/ui/util/PreviewSampleData.kt
+++ b/app/src/main/java/com/piledrive/inventory/ui/util/PreviewSampleData.kt
@@ -9,6 +9,7 @@ import com.piledrive.inventory.data.model.Stash
 import com.piledrive.inventory.data.model.Tag
 import com.piledrive.inventory.data.model.composite.StashesForItem
 import com.piledrive.inventory.data.model.composite.ItemWithTagsContent
+import com.piledrive.inventory.ui.state.FilterOptions
 import com.piledrive.inventory.ui.state.FullItemsContentState
 import com.piledrive.inventory.ui.state.ItemContentState
 import com.piledrive.inventory.ui.state.ItemOptions
@@ -47,6 +48,13 @@ fun previewTagsContentFlow(
 			hasLoaded = true,
 			isLoading = false
 		)
+	)
+}
+
+fun previewFilterOptionsFlow(
+): StateFlow<FilterOptions> {
+	return MutableStateFlow(
+		FilterOptions()
 	)
 }
 

--- a/app/src/main/java/com/piledrive/inventory/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/piledrive/inventory/viewmodel/MainViewModel.kt
@@ -283,11 +283,12 @@ class MainViewModel @Inject constructor(
 
 	// todo - resolve this with powersync queries, relations
 	private suspend fun rebuildItemsWithTags() {
-		val locations = userLocationsContent.data.userLocations
 		val items = itemsDataCollector.itemsContentFlow.value.data.items
 		val tags = itemsDataCollector.userTagsContentFlow.value.data.userTags
 		val item2Tags = itemsDataCollector.item2TagsContentFlow.value
 		val quantityUnits = itemsDataCollector.quantityUnitsContentFlow.value.data.allUnits
+
+		val locations = userLocationsContent.data.userLocations
 		val stashes = itemStashesContent.data.itemStashes
 
 		val currLocation = filterOptions.currentLocation

--- a/app/src/main/java/com/piledrive/inventory/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/piledrive/inventory/viewmodel/MainViewModel.kt
@@ -49,11 +49,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -169,6 +168,7 @@ class MainViewModel @Inject constructor(
 	private fun changeLocation(loc: Location) {
 		viewModelScope.launch {
 			filterOptions = filterOptions.copy(currentLocation = loc)
+			_filterOptionsFlow.value = filterOptions
 			rebuildItemsWithTags()
 		}
 	}
@@ -225,11 +225,14 @@ class MainViewModel @Inject constructor(
 	}
 
 	private var filterOptions = FilterOptions()
+	private val _filterOptionsFlow = MutableStateFlow(filterOptions)
+	val filterOptionsFlow: StateFlow<FilterOptions> = _filterOptionsFlow
 
 	//todo: possible add pref, or keep it session-level
 	private fun changeTag(tag: Tag) {
 		viewModelScope.launch {
 			filterOptions = filterOptions.copy(currentTag = tag)
+			_filterOptionsFlow.value = filterOptions
 			rebuildItemsWithTags()
 		}
 	}
@@ -457,6 +460,7 @@ class MainViewModel @Inject constructor(
 		_locationStashesContentFlow,
 		locationsSourceFlow = _userLocationsContentFlow,
 		tagsSourceFlow = itemsDataCollector.userTagsContentFlow,
+		filterOptionsFlow = filterOptionsFlow,
 		itemMenuCoordinator = ListItemOverflowMenuCoordinator(),
 		onItemStashQuantityUpdated = { stashId, qty ->
 			updateStashQuantity(stashId, qty)

--- a/app/src/main/java/com/piledrive/inventory/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/piledrive/inventory/viewmodel/MainViewModel.kt
@@ -1,4 +1,4 @@
-@file:OptIn(ExperimentalCoroutinesApi::class)
+@file:OptIn(FlowPreview::class)
 
 package com.piledrive.inventory.viewmodel
 
@@ -6,7 +6,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.piledrive.inventory.data.enums.SortOrder
-import com.piledrive.inventory.data.model.Item2Tag
 import com.piledrive.inventory.data.model.ItemSlug
 import com.piledrive.inventory.data.model.Location
 import com.piledrive.inventory.data.model.LocationSlug
@@ -39,17 +38,16 @@ import com.piledrive.inventory.ui.state.LocalizedContentState
 import com.piledrive.inventory.ui.state.LocalizedStashesPayload
 import com.piledrive.inventory.ui.state.LocationOptions
 import com.piledrive.inventory.ui.state.TagOptions
-import com.piledrive.inventory.viewmodel.nuggets.ItemsCollector
-import com.piledrive.inventory.viewmodel.nuggets.StashesCollector
+import com.piledrive.inventory.viewmodel.data_collectors.ItemsCollector
+import com.piledrive.inventory.viewmodel.data_collectors.StashesCollector
 import com.piledrive.lib_compose_components.ui.coordinators.ListItemOverflowMenuCoordinator
 import com.piledrive.lib_compose_components.ui.dropdown.readonly.ReadOnlyDropdownCoordinatorGeneric
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
@@ -208,7 +206,6 @@ class MainViewModel @Inject constructor(
 
 	private var filterOptions = FilterOptions()
 	private val _filterOptionsFlow = MutableStateFlow(filterOptions)
-	val filterOptionsFlow: StateFlow<FilterOptions> = _filterOptionsFlow
 
 	//todo: possible add pref, or keep it session-level
 	private fun changeTag(tag: Tag) {
@@ -436,7 +433,7 @@ class MainViewModel @Inject constructor(
 		_locationStashesContentFlow,
 		locationsSourceFlow = stashesDataCollector.locationsContentFlow,
 		tagsSourceFlow = itemsDataCollector.userTagsContentFlow,
-		filterOptionsFlow = filterOptionsFlow,
+		filterOptionsFlow = _filterOptionsFlow,
 		itemMenuCoordinator = ListItemOverflowMenuCoordinator(),
 		onItemStashQuantityUpdated = { stashId, qty ->
 			updateStashQuantity(stashId, qty)

--- a/app/src/main/java/com/piledrive/inventory/viewmodel/ManageItemsViewModel.kt
+++ b/app/src/main/java/com/piledrive/inventory/viewmodel/ManageItemsViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.piledrive.inventory.data.enums.SortOrder
 import com.piledrive.inventory.data.model.ItemSlug
-import com.piledrive.inventory.data.model.QuantityUnit
 import com.piledrive.inventory.data.model.QuantityUnitSlug
 import com.piledrive.inventory.data.model.TagSlug
 import com.piledrive.inventory.data.model.composite.FullItemData
@@ -18,11 +17,10 @@ import com.piledrive.inventory.ui.modal.create_tag.CreateTagSheetCoordinator
 import com.piledrive.inventory.ui.modal.create_unit.CreateQuantityUnitSheetCoordinator
 import com.piledrive.inventory.ui.screens.items.content.ManageItemsContentCoordinator
 import com.piledrive.inventory.ui.state.FullItemsContentState
-import com.piledrive.inventory.viewmodel.nuggets.ItemsCollector
+import com.piledrive.inventory.viewmodel.data_collectors.ItemsCollector
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.launch
@@ -126,8 +124,7 @@ class ManageItemsViewModel @Inject constructor(
 	/////////////////////////////////////////////////
 
 	private var fullItemsContent: FullItemsContentState = FullItemsContentState()
-	private val _fullItemsContentFlow = MutableStateFlow<FullItemsContentState>(fullItemsContent)
-	val fullItemsContentFlow: StateFlow<FullItemsContentState> = _fullItemsContentFlow
+	private val _fullItemsContentFlow = MutableStateFlow(fullItemsContent)
 
 	// todo - resolve this with powersync queries, relations
 	private suspend fun rebuildItemsWithTags() {
@@ -180,7 +177,7 @@ class ManageItemsViewModel @Inject constructor(
 	/////////////////////////////////////////////////
 
 	val contentCoordinator = ManageItemsContentCoordinator(
-		itemsSourceFlow = fullItemsContentFlow,
+		itemsSourceFlow = _fullItemsContentFlow,
 		createItemCoordinator = CreateItemSheetCoordinator(
 			itemsSourceFlow = itemsDataCollector.itemsContentFlow,
 			unitsSourceFlow = itemsDataCollector.quantityUnitsContentFlow,

--- a/app/src/main/java/com/piledrive/inventory/viewmodel/ManageLocationsViewModel.kt
+++ b/app/src/main/java/com/piledrive/inventory/viewmodel/ManageLocationsViewModel.kt
@@ -12,7 +12,6 @@ import com.piledrive.inventory.ui.state.LocationOptions
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -56,8 +55,7 @@ class ManageLocationsViewModel @Inject constructor(
 	/////////////////////////////////////////////////
 
 	private var userLocationsContent: LocationContentState = LocationContentState()
-	private val _userLocationContentFlow = MutableStateFlow<LocationContentState>(userLocationsContent)
-	val userLocationContentFlow: StateFlow<LocationContentState> = _userLocationContentFlow
+	private val _userLocationContentFlow = MutableStateFlow(userLocationsContent)
 
 	private fun watchLocations() {
 		viewModelScope.launch {
@@ -101,9 +99,9 @@ class ManageLocationsViewModel @Inject constructor(
 	/////////////////////////////////////////////////
 
 	val contentCoordinator = ManageLocationsContentCoordinator(
-		locationsSourceFlow = userLocationContentFlow,
+		locationsSourceFlow = _userLocationContentFlow,
 		createLocationCoordinator = CreateLocationModalSheetCoordinator(
-			locationsSourceFlow = userLocationContentFlow,
+			locationsSourceFlow = _userLocationContentFlow,
 			onCreateDataModel = {
 				addNewLocation(it)
 			},

--- a/app/src/main/java/com/piledrive/inventory/viewmodel/ManageLocationsViewModel.kt
+++ b/app/src/main/java/com/piledrive/inventory/viewmodel/ManageLocationsViewModel.kt
@@ -69,7 +69,6 @@ class ManageLocationsViewModel @Inject constructor(
 						data = LocationOptions(
 							allLocations = flatLocations,
 							userLocations = it,
-							currentLocation = userLocationsContent.data.currentLocation
 						),
 						hasLoaded = true,
 						isLoading = false

--- a/app/src/main/java/com/piledrive/inventory/viewmodel/ManageTagsViewModel.kt
+++ b/app/src/main/java/com/piledrive/inventory/viewmodel/ManageTagsViewModel.kt
@@ -12,7 +12,6 @@ import com.piledrive.inventory.ui.state.TagsContentState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -57,8 +56,7 @@ class ManageTagsViewModel @Inject constructor(
 	/////////////////////////////////////////////////
 
 	private var userTagsContent: TagsContentState = TagsContentState()
-	private val _userTagsContentFlow = MutableStateFlow<TagsContentState>(userTagsContent)
-	val userTagsContentFlow: StateFlow<TagsContentState> = _userTagsContentFlow
+	private val _userTagsContentFlow = MutableStateFlow(userTagsContent)
 
 	private fun watchTags() {
 		viewModelScope.launch {
@@ -80,13 +78,13 @@ class ManageTagsViewModel @Inject constructor(
 		}
 	}
 
-	fun addNewTag(slug: TagSlug) {
+	private fun addNewTag(slug: TagSlug) {
 		viewModelScope.launch {
 			tagsRepo.addTag(slug)
 		}
 	}
 
-	fun updateTag(tag: Tag) {
+	private fun updateTag(tag: Tag) {
 		viewModelScope.launch {
 			tagsRepo.updateTag(tag)
 		}
@@ -100,9 +98,9 @@ class ManageTagsViewModel @Inject constructor(
 	/////////////////////////////////////////////////
 
 	val contentCoordinator = ManageTagsContentCoordinator(
-		tagsSourceFlow = userTagsContentFlow,
+		tagsSourceFlow = _userTagsContentFlow,
 		createTagCoordinator = CreateTagSheetCoordinator(
-			userTagsContentFlow,
+			_userTagsContentFlow,
 			onCreateDataModel = {
 				addNewTag(it)
 			},

--- a/app/src/main/java/com/piledrive/inventory/viewmodel/ManageUnitsViewModel.kt
+++ b/app/src/main/java/com/piledrive/inventory/viewmodel/ManageUnitsViewModel.kt
@@ -11,7 +11,6 @@ import com.piledrive.inventory.ui.state.QuantityUnitContentState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -56,10 +55,9 @@ class ManageUnitsViewModel @Inject constructor(
 	/////////////////////////////////////////////////
 
 	private var unitsContent: QuantityUnitContentState = QuantityUnitContentState()
-	private val _unitsContentFlow = MutableStateFlow<QuantityUnitContentState>(unitsContent)
-	val unitsContentFlow: StateFlow<QuantityUnitContentState> = _unitsContentFlow
+	private val _unitsContentFlow = MutableStateFlow(unitsContent)
 
-	fun addNewQuantityUnit(slug: QuantityUnitSlug) {
+	private fun addNewQuantityUnit(slug: QuantityUnitSlug) {
 		viewModelScope.launch {
 			unitsRepo.addQuantityUnit(slug)
 		}
@@ -95,9 +93,9 @@ class ManageUnitsViewModel @Inject constructor(
 	/////////////////////////////////////////////////
 
 	val contentCoordinator = ManageUnitsContentCoordinator(
-		unitsSourceFlow = unitsContentFlow,
+		unitsSourceFlow = _unitsContentFlow,
 		createQuantityUnitSheetCoordinator = CreateQuantityUnitSheetCoordinator(
-			unitsContentFlow,
+			_unitsContentFlow,
 			onCreateDataModel = {
 				addNewQuantityUnit(it)
 			},

--- a/app/src/main/java/com/piledrive/inventory/viewmodel/data_collectors/ItemsCollector.kt
+++ b/app/src/main/java/com/piledrive/inventory/viewmodel/data_collectors/ItemsCollector.kt
@@ -1,6 +1,6 @@
 @file:OptIn(ExperimentalCoroutinesApi::class)
 
-package com.piledrive.inventory.viewmodel.nuggets
+package com.piledrive.inventory.viewmodel.data_collectors
 
 import com.piledrive.inventory.data.model.Item
 import com.piledrive.inventory.data.model.Item2Tag

--- a/app/src/main/java/com/piledrive/inventory/viewmodel/data_collectors/StashesCollector.kt
+++ b/app/src/main/java/com/piledrive/inventory/viewmodel/data_collectors/StashesCollector.kt
@@ -1,15 +1,11 @@
 @file:OptIn(ExperimentalCoroutinesApi::class)
 
-package com.piledrive.inventory.viewmodel.nuggets
+package com.piledrive.inventory.viewmodel.data_collectors
 
 import com.piledrive.inventory.data.model.Location
-import com.piledrive.inventory.data.model.QuantityUnit
 import com.piledrive.inventory.data.model.Stash
-import com.piledrive.inventory.data.model.composite.FullItemData
-import com.piledrive.inventory.data.model.composite.FullItemsContent
 import com.piledrive.inventory.data.model.composite.FullStashData
 import com.piledrive.inventory.data.model.composite.FullStashesContent
-import com.piledrive.inventory.ui.state.FullItemsContentState
 import com.piledrive.inventory.ui.state.FullStashesContentState
 import com.piledrive.inventory.ui.state.ItemStashContentState
 import com.piledrive.inventory.ui.state.LocationContentState

--- a/app/src/main/java/com/piledrive/inventory/viewmodel/nuggets/ItemsCollector.kt
+++ b/app/src/main/java/com/piledrive/inventory/viewmodel/nuggets/ItemsCollector.kt
@@ -6,38 +6,58 @@ import com.piledrive.inventory.data.model.Item
 import com.piledrive.inventory.data.model.Item2Tag
 import com.piledrive.inventory.data.model.QuantityUnit
 import com.piledrive.inventory.data.model.Tag
+import com.piledrive.inventory.data.model.composite.FullItemData
+import com.piledrive.inventory.data.model.composite.FullItemsContent
+import com.piledrive.inventory.ui.state.FullItemsContentState
 import com.piledrive.inventory.ui.state.ItemContentState
 import com.piledrive.inventory.ui.state.QuantityUnitContentState
 import com.piledrive.inventory.ui.state.TagOptions
 import com.piledrive.inventory.ui.state.TagsContentState
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 class ItemsCollector(
-	private val itemsSourceFlow: Flow<List<Item>>,
-	private val unitsSourceFlow: Flow<List<QuantityUnit>>,
-	private val tagsSourceFlow: Flow<List<Tag>>,
-	private val items2TagsSourceFlow: Flow<List<Item2Tag>>,
+	coroutineScope: CoroutineScope,
+	itemsSourceFlow: Flow<List<Item>>,
+	unitsSourceFlow: Flow<List<QuantityUnit>>,
+	tagsSourceFlow: Flow<List<Tag>>,
+	items2TagsSourceFlow: Flow<List<Item2Tag>>,
 ) {
 
 	init {
-		watchItems()
-		watchQuantityUnits()
-		watchTags()
-		watchItem2Tags()
+		coroutineScope.launch(Dispatchers.Default) {
+			val itemsSource = watchItems(itemsSourceFlow)
+			val unitsSource = watchQuantityUnits(unitsSourceFlow)
+			val tagsSource = watchTags(tagsSourceFlow)
+			val item2TagsSource = watchItem2Tags(items2TagsSourceFlow)
+
+			merge(itemsSource, tagsSource, item2TagsSource, unitsSource)
+				.debounce(500)
+				.collect {
+					rebuildItemsWithTags()
+				}
+		}
 	}
+
+
+	//  region Raw data model inputs
+	/////////////////////////////////////////////////
 
 	private var itemsContent: ItemContentState = ItemContentState()
 	private val _itemsContentFlow = MutableStateFlow(itemsContent)
 	val itemsContentFlow: StateFlow<ItemContentState> = _itemsContentFlow
 
-	private fun watchItems(): Flow<Unit> {
+	private fun watchItems(itemsSourceFlow: Flow<List<Item>>): Flow<Unit> {
 		return itemsSourceFlow.mapLatest {
 			Timber.d("Items received: $it")
 			itemsContent = itemsContent.copy(
@@ -53,7 +73,7 @@ class ItemsCollector(
 	private val _quantityUnitsContentFlow = MutableStateFlow<QuantityUnitContentState>(quantityUnitsContent)
 	val quantityUnitsContentFlow: StateFlow<QuantityUnitContentState> = _quantityUnitsContentFlow
 
-	private fun watchQuantityUnits(): Flow<Unit> {
+	private fun watchQuantityUnits(unitsSourceFlow: Flow<List<QuantityUnit>>): Flow<Unit> {
 		return unitsSourceFlow.mapLatest {
 			Timber.d("Units received: $it")
 			quantityUnitsContent = quantityUnitsContent.copy(
@@ -69,7 +89,7 @@ class ItemsCollector(
 	private val _userTagsContentFlow = MutableStateFlow(userTagsContent)
 	val userTagsContentFlow: StateFlow<TagsContentState> = _userTagsContentFlow
 
-	private fun watchTags(): Flow<Unit> {
+	private fun watchTags(tagsSourceFlow: Flow<List<Tag>>): Flow<Unit> {
 		return tagsSourceFlow.mapLatest {
 			Timber.d("Tags received: $it")
 			userTagsContent = userTagsContent.copy(
@@ -89,7 +109,7 @@ class ItemsCollector(
 	private val _item2TagsContentFlow = MutableStateFlow(item2Tags)
 	val item2TagsContentFlow: StateFlow<List<Item2Tag>> = _item2TagsContentFlow
 
-	private fun watchItem2Tags(): Flow<Unit> {
+	private fun watchItem2Tags(items2TagsSourceFlow: Flow<List<Item2Tag>>): Flow<Unit> {
 		return items2TagsSourceFlow.mapLatest {
 			Timber.d("Items2Tags received: $it")
 			item2Tags.clear()
@@ -99,4 +119,43 @@ class ItemsCollector(
 			}
 		}
 	}
+
+	/////////////////////////////////////////////////
+	//  endregion
+
+
+	//  region Composite data outputs
+	/////////////////////////////////////////////////
+
+	private var fullItemsContent: FullItemsContentState = FullItemsContentState()
+	private val _fullItemsContentFlow = MutableStateFlow<FullItemsContentState>(fullItemsContent)
+	val fullItemsContentFlow: StateFlow<FullItemsContentState> = _fullItemsContentFlow
+
+	// todo - resolve this with powersync queries, relations
+	// todo - add optional state for current tag to filter by to keep optimization in mainviewmodel
+	private suspend fun rebuildItemsWithTags() {
+		val items = itemsContent.data.items
+		val quantityUnits = quantityUnitsContent.data.allUnits
+		val tags = userTagsContent.data.userTags
+		val item2Tags = item2Tags
+
+		val unsortedFullItems: List<FullItemData> = items.map { item ->
+			val tagIdsForItem = item2Tags.filter { it.itemId == item.id }.map { it.tagId }
+			val tagsForItem = tags.filter { tagIdsForItem.contains(it.id) }
+			val unitForItem = quantityUnits.firstOrNull { it.id == item.unitId } ?: QuantityUnit.defaultUnitBags
+			FullItemData(item, unitForItem, tagsForItem)
+		}
+		val content = FullItemsContent(
+			unsortedFullItems
+		)
+		val updated = fullItemsContent.copy(
+			data = content
+		)
+		withContext(Dispatchers.Main) {
+			_fullItemsContentFlow.value = updated
+		}
+	}
+
+	/////////////////////////////////////////////////
+	//  endregion
 }

--- a/app/src/main/java/com/piledrive/inventory/viewmodel/nuggets/ItemsCollector.kt
+++ b/app/src/main/java/com/piledrive/inventory/viewmodel/nuggets/ItemsCollector.kt
@@ -1,0 +1,102 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.piledrive.inventory.viewmodel.nuggets
+
+import com.piledrive.inventory.data.model.Item
+import com.piledrive.inventory.data.model.Item2Tag
+import com.piledrive.inventory.data.model.QuantityUnit
+import com.piledrive.inventory.data.model.Tag
+import com.piledrive.inventory.ui.state.ItemContentState
+import com.piledrive.inventory.ui.state.QuantityUnitContentState
+import com.piledrive.inventory.ui.state.TagOptions
+import com.piledrive.inventory.ui.state.TagsContentState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+class ItemsCollector(
+	private val itemsSourceFlow: Flow<List<Item>>,
+	private val unitsSourceFlow: Flow<List<QuantityUnit>>,
+	private val tagsSourceFlow: Flow<List<Tag>>,
+	private val items2TagsSourceFlow: Flow<List<Item2Tag>>,
+) {
+
+	init {
+		watchItems()
+		watchQuantityUnits()
+		watchTags()
+		watchItem2Tags()
+	}
+
+	private var itemsContent: ItemContentState = ItemContentState()
+	private val _itemsContentFlow = MutableStateFlow(itemsContent)
+	val itemsContentFlow: StateFlow<ItemContentState> = _itemsContentFlow
+
+	private fun watchItems(): Flow<Unit> {
+		return itemsSourceFlow.mapLatest {
+			Timber.d("Items received: $it")
+			itemsContent = itemsContent.copy(
+				data = itemsContent.data.copy(items = it)
+			)
+			withContext(Dispatchers.Main) {
+				_itemsContentFlow.value = itemsContent
+			}
+		}
+	}
+
+	private var quantityUnitsContent: QuantityUnitContentState = QuantityUnitContentState()
+	private val _quantityUnitsContentFlow = MutableStateFlow<QuantityUnitContentState>(quantityUnitsContent)
+	val quantityUnitsContentFlow: StateFlow<QuantityUnitContentState> = _quantityUnitsContentFlow
+
+	private fun watchQuantityUnits(): Flow<Unit> {
+		return unitsSourceFlow.mapLatest {
+			Timber.d("Units received: $it")
+			quantityUnitsContent = quantityUnitsContent.copy(
+				data = quantityUnitsContent.data.copy(customUnits = it)
+			)
+			withContext(Dispatchers.Main) {
+				_quantityUnitsContentFlow.value = quantityUnitsContent
+			}
+		}
+	}
+
+	private var userTagsContent: TagsContentState = TagsContentState()
+	private val _userTagsContentFlow = MutableStateFlow(userTagsContent)
+	val userTagsContentFlow: StateFlow<TagsContentState> = _userTagsContentFlow
+
+	private fun watchTags(): Flow<Unit> {
+		return tagsSourceFlow.mapLatest {
+			Timber.d("Tags received: $it")
+			userTagsContent = userTagsContent.copy(
+				data = TagOptions(
+					userTags = it,
+				),
+				hasLoaded = true,
+				isLoading = false
+			)
+			withContext(Dispatchers.Main) {
+				_userTagsContentFlow.value = userTagsContent
+			}
+		}
+	}
+
+	private val item2Tags = mutableListOf<Item2Tag>()
+	private val _item2TagsContentFlow = MutableStateFlow(item2Tags)
+	val item2TagsContentFlow: StateFlow<List<Item2Tag>> = _item2TagsContentFlow
+
+	private fun watchItem2Tags(): Flow<Unit> {
+		return items2TagsSourceFlow.mapLatest {
+			Timber.d("Items2Tags received: $it")
+			item2Tags.clear()
+			item2Tags.addAll(it)
+			withContext(Dispatchers.Main) {
+				_item2TagsContentFlow.value = item2Tags
+			}
+		}
+	}
+}

--- a/app/src/main/java/com/piledrive/inventory/viewmodel/nuggets/StashesCollector.kt
+++ b/app/src/main/java/com/piledrive/inventory/viewmodel/nuggets/StashesCollector.kt
@@ -1,0 +1,123 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.piledrive.inventory.viewmodel.nuggets
+
+import com.piledrive.inventory.data.model.Location
+import com.piledrive.inventory.data.model.QuantityUnit
+import com.piledrive.inventory.data.model.Stash
+import com.piledrive.inventory.data.model.composite.FullItemData
+import com.piledrive.inventory.data.model.composite.FullItemsContent
+import com.piledrive.inventory.data.model.composite.FullStashData
+import com.piledrive.inventory.data.model.composite.FullStashesContent
+import com.piledrive.inventory.ui.state.FullItemsContentState
+import com.piledrive.inventory.ui.state.FullStashesContentState
+import com.piledrive.inventory.ui.state.ItemStashContentState
+import com.piledrive.inventory.ui.state.LocationContentState
+import com.piledrive.inventory.ui.state.LocationOptions
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+class StashesCollector(
+	coroutineScope: CoroutineScope,
+	locationsSourceFlow: Flow<List<Location>>,
+	stashesSourceFlow: Flow<List<Stash>>
+) {
+
+	init {
+		coroutineScope.launch(Dispatchers.Default) {
+			val locationsSource = watchLocations(locationsSourceFlow)
+			val stashesSource = watchItemStashes(stashesSourceFlow)
+
+			merge(locationsSource, stashesSource)
+				.debounce(500)
+				.collect {
+					rebuildStashesWithLocations()
+				}
+		}
+	}
+
+	//  region Raw data model inputs
+	/////////////////////////////////////////////////
+
+	private var locationsContent: LocationContentState = LocationContentState()
+	private val _locationsContentFlow = MutableStateFlow(locationsContent)
+	val locationsContentFlow: StateFlow<LocationContentState> = _locationsContentFlow
+
+	private fun watchLocations(locationsSourceFlow: Flow<List<Location>>): Flow<Unit> {
+		return locationsSourceFlow.mapLatest {
+			Timber.d("Locations received: $it")
+			val flatLocations = listOf(LocationOptions.defaultLocation, *it.toTypedArray())
+			locationsContent = LocationContentState(
+				data = LocationOptions(
+					allLocations = flatLocations,
+					userLocations = it,
+				),
+				hasLoaded = true,
+				isLoading = false
+			)
+			withContext(Dispatchers.Main) {
+				_locationsContentFlow.value = locationsContent
+			}
+		}
+	}
+
+
+	private var itemStashesContent: ItemStashContentState = ItemStashContentState()
+	private val _itemStashesContentFlow = MutableStateFlow(itemStashesContent)
+	val itemStashesContentFlow: StateFlow<ItemStashContentState> = _itemStashesContentFlow
+
+	private fun watchItemStashes(stashesSourceFlow: Flow<List<Stash>>): Flow<Unit> {
+		return stashesSourceFlow.mapLatest {
+			Timber.d("Stashes received: $it")
+			itemStashesContent = itemStashesContent.copy(
+				data = itemStashesContent.data.copy(itemStashes = it)
+			)
+			withContext(Dispatchers.Main) {
+				_itemStashesContentFlow.value = itemStashesContent
+			}
+		}
+	}
+
+	/////////////////////////////////////////////////
+	//  endregion
+
+
+	//  region Composite data outputs
+	/////////////////////////////////////////////////
+
+	private var fullStashesContent: FullStashesContentState = FullStashesContentState()
+	private val _fullStashesContentFlow = MutableStateFlow<FullStashesContentState>(fullStashesContent)
+	val fullStashesContentFlow: StateFlow<FullStashesContentState> = _fullStashesContentFlow
+
+	private suspend fun rebuildStashesWithLocations() {
+		val locations = locationsContent.data.userLocations
+		val stashes = itemStashesContent.data.itemStashes
+
+		val unsortedFullStashes: List<FullStashData> = stashes.mapNotNull { stash ->
+			val location = locations.firstOrNull { it.id == stash.locationId } ?: return@mapNotNull null
+			FullStashData(location = location, stash = stash)
+		}
+		val content = FullStashesContent(
+			unsortedFullStashes
+		)
+		val updated = fullStashesContent.copy(
+			data = content
+		)
+		withContext(Dispatchers.Main) {
+			_fullStashesContentFlow.value = updated
+		}
+	}
+
+	/////////////////////////////////////////////////
+	//  endregion
+}

--- a/app/src/test/java/com/piledrive/inventory/ScreenContentCoordinatorUnitTests.kt
+++ b/app/src/test/java/com/piledrive/inventory/ScreenContentCoordinatorUnitTests.kt
@@ -1,6 +1,6 @@
 package com.piledrive.inventory
 
-import com.piledrive.inventory.data.model.composite.ItemWithTagsContent
+import com.piledrive.inventory.data.model.composite.FullItemsContent
 import com.piledrive.inventory.ui.modal.create_item.CreateItemSheetCoordinator
 import com.piledrive.inventory.ui.modal.create_location.CreateLocationModalSheetCoordinator
 import com.piledrive.inventory.ui.modal.create_tag.CreateTagSheetCoordinator
@@ -28,7 +28,7 @@ import org.junit.Test
 class ScreenContentCoordinatorUnitTests {
 	@Test
 	fun manage_items_coordinator_actions_tests() {
-		val sampleData = ItemWithTagsContent.generateSampleSet()
+		val sampleData = FullItemsContent.generateSampleSet()
 		val coordinator = ManageItemsContentCoordinator(
 			itemsSourceFlow = previewFullItemsContentFlow(sampleData),
 			createItemCoordinator = CreateItemSheetCoordinator(


### PR DESCRIPTION
misc. cleanup & performance improvements:
- changing hilt scopes to singletons to avoid remote reconnections on nav
- refactoring some composite data models to have clearer names (ItemWithTagsContent  -> FullItemsContent) & more deliberate use (FilterOptions)
- add "data collector" classes to deduplicate compiling common composite date models (items + tagIds + tags + units, etc.) across viewmodels
- refactor viewmodels' remote data subscriptions to be merged & debounced to reduce initial n-per-stream ui reloads